### PR TITLE
Added stars and fixed broken links via awesome-lists-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,21 @@ A curated list of chart and dataviz resources that developers may find useful. F
 * [C3.js](http://c3js.org/) - D3 based reusable chart library.
 * [Chart.js](http://www.chartjs.org/) - Tiny library (11kb!) including core chart types.
 * [Chartist](https://gionkunz.github.io/chartist-js/) - Simple, lightweight chart library that uses SVG to render the chart, and CSS to style it.
-* [Chartkick](https://github.com/ankane/chartkick) - JavaScript charts with one line of Ruby.
+* [**Chartkick ★3,578**](https://github.com/ankane/chartkick) - JavaScript charts with one line of Ruby.
 * [D3.js](https://d3js.org/) - Allows the user to manipulate documents based on data to render charts in SVG.
 * [dc.js](https://dc-js.github.io/dc.js/) - D3 Library with [crossfilter](http://square.github.io/crossfilter/) support
-* [dygraphs](https://github.com/danvk/dygraphs) - Interactive zoomable time series charts.
-* [ECharts](https://github.com/ecomfe/echarts) - A powerful charting and visualization library for browser.
-* [EJSChart](https://github.com/EmpriseCorporation/EJSCharts) - enterprise ready charting library.
-* [Graphosaurus](https://github.com/frewsxcv/graphosaurus) - 3D graph viewer powered by WebGL (three.js)
+* [**dygraphs ★1,847**](https://github.com/danvk/dygraphs) - Interactive zoomable time series charts.
+* [**ECharts ★11,423**](https://github.com/ecomfe/echarts) - A powerful charting and visualization library for browser.
+* [EJSChart ★7](https://github.com/EmpriseCorporation/EJSCharts) - enterprise ready charting library.
+* [Graphosaurus ★202](https://github.com/frewsxcv/graphosaurus) - 3D graph viewer powered by WebGL (three.js)
 * [Morris.js](http://morrisjs.github.io/morris.js) - Simple API to render line, bar, area, and donut charts
-* [Plotly](https://github.com/plotly/plotly.js) - Built on top of d3 and stack.gl, allowing users to create basic charts and SVG maps.
-* [Plottable](https://github.com/palantir/plottable) - Library with OOP style syntax to build charts.
+* [**Plotly ★4,549**](https://github.com/plotly/plotly.js) - Built on top of d3 and stack.gl, allowing users to create basic charts and SVG maps.
+* [**Plottable ★976**](https://github.com/palantir/plottable) - Library with OOP style syntax to build charts.
 * [rgraph](http://www.rgraph.net/) - 2D/3D javascript charts with google sheets import capabilites.
-* [sigma.js](https://github.com/jacomyal/sigma.js) - Graphs / Network diagram library built with canvas.
-* [Smoothie Charts](https://github.com/joewalnes/smoothie) - JavaScript charts for realtime streaming data.
+* [**sigma.js ★6,113**](https://github.com/jacomyal/sigma.js) - Graphs / Network diagram library built with canvas.
+* [**Smoothie Charts ★1,457**](https://github.com/joewalnes/smoothie) - JavaScript charts for realtime streaming data.
 * [TauCharts](https://www.taucharts.com/) - Unique syntax that lets the developer describe the data using DSL. Has the ability to create facets.
-* [uvCharts](https://github.com/imaginea/uvCharts) - JavaScript Charting library built using d3.js
+* [uvCharts ★177](https://github.com/Imaginea/uvCharts) - JavaScript Charting library built using d3.js
 * [vis.js](http://visjs.org/) - Network diagrams, descriptive timelines with labels, and has 3D graphs.
 
 ---
@@ -57,7 +57,7 @@ A curated list of chart and dataviz resources that developers may find useful. F
 ### Framework-Specific Libraries
 #### Angular
 * [Angular-Chart](http://jtblin.github.io/angular-chart.js)- Simple API to render line, bar, area, and donut charts
-* [n3-charts](https://github.com/n3-charts/line-chart) - Easy to use library written with AngularJS, rendering charts with D3.
+* [**n3-charts ★1,135**](https://github.com/n3-charts/line-chart) - Easy to use library written with AngularJS, rendering charts with D3.
 
 #### Ember
 * [Ember Charts](http://addepar.github.io/ember-charts/#/overview) - Five basic chart types ready to go in Ember.js projects.
@@ -67,9 +67,9 @@ A curated list of chart and dataviz resources that developers may find useful. F
 * [jqPlot](http://www.jqplot.com) - Open source jQuery plugin for drawing charts. Contains many commonly used features but may use different naming conventions for these items.
 
 #### React
-* [Formiddable](https://github.com/FormidableLabs/victory) - A collection of composable React components for building interactive data visualizations
-* [react-d3](https://github.com/esbullington/react-d3) - Charting library that relies on React for generating SVG markup and d3 to calculate path values.
-* [react-vis](https://github.com/uber-common/react-vis) - A collection of React components to render common data visualization charts
+* [**Formiddable ★1,028**](https://github.com/FormidableLabs/victory) - A collection of composable React components for building interactive data visualizations
+* [**react-d3 ★1,094**](https://github.com/esbullington/react-d3) - Charting library that relies on React for generating SVG markup and d3 to calculate path values.
+* [**react-vis ★808**](https://github.com/uber/react-vis) - A collection of React components to render common data visualization charts
 * [recharts](http://recharts.org) - Redefined chart library built with React and D3
 
 ---


### PR DESCRIPTION
This Pull Request has been generated automatically by awesome-lists-bot, which was created by @ColinEberhardt. The aim of this bot is to improve the overall standard of the various GitHub-based 'awesome' lists.

For questions / comments regarding the bot, or to have your awesome repo removed from the list, please add an issue here:

https://github.com/ColinEberhardt/awesome-lists-bot

Currently the bot does the following:
- Removes links that returns 404s (please double check these deletions before merging in case it is a temporary issue)
- Add a star count for repos, this helps people find popular projects (especially useful for big lists!)
- Resolve redirects, updating the project / org name when a redirect is found.

Although I am beta-testing some of these features on a subset of awesome lists.

Here's a summary of changes as part of this PR:

Awesome link checker verified 42 links, finding 1 broken
- [403] http://www.visualisingdata.com [Not removed from list]
