### PR TITLE
Remove duplicate entry for react-vis library

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ A declarative, efficient, and simple JavaScript library for building responsive 
 * [react-chart-js](https://github.com/jerairrest/react-chartjs-2) - React wrapper for Chart.js
 * [react-d3](https://github.com/esbullington/react-d3) - Charting library that relies on React for generating SVG markup and d3 to calculate path values.
 * [react-muze](https://github.com/chartshq/react-muze) - React wrapper for [muze](https://muzejs.org/) (free data visualization library for creating exploratory data visualizations in browser, using WebAssembly)
-* [react-vis](https://github.com/uber-common/react-vis) - A collection of React components to render common data visualization charts
 * [recharts](http://recharts.org) - Redefined chart library built with React and D3
 * [Victory](https://github.com/FormidableLabs/victory) - A collection of composable React components for building interactive data visualizations
 


### PR DESCRIPTION
Line 86 already has `react-vis` library.
Removed line 92 over 82 because it used old repository url .